### PR TITLE
Specify run order

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -1296,7 +1296,8 @@ public abstract class AbstractSurefireMojo
         ClassLoaderConfiguration classLoaderConfiguration = getClassLoaderConfiguration();
         provider.addProviderProperties();
         RunOrderParameters runOrderParameters =
-            new RunOrderParameters( getRunOrder(), getStatisticsFile( getConfigChecksum() ), getRunOrderRandomSeed() );
+            new RunOrderParameters( getRunOrder(), getStatisticsFile( getConfigChecksum() ), getRunOrderRandomSeed(),
+                                    getTest() );
 
         if ( isNotForking() )
         {

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializer.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializer.java
@@ -65,6 +65,7 @@ import static org.apache.maven.surefire.booter.BooterConstants.RUN_STATISTICS_FI
 import static org.apache.maven.surefire.booter.BooterConstants.SHUTDOWN;
 import static org.apache.maven.surefire.booter.BooterConstants.SOURCE_DIRECTORY;
 import static org.apache.maven.surefire.booter.BooterConstants.SPECIFIC_TEST_PROPERTY_PREFIX;
+import static org.apache.maven.surefire.booter.BooterConstants.SPECIFIED_RUN_ORDER;
 import static org.apache.maven.surefire.booter.BooterConstants.SYSTEM_EXIT_TIMEOUT;
 import static org.apache.maven.surefire.booter.BooterConstants.TEST_CLASSES_DIRECTORY;
 import static org.apache.maven.surefire.booter.BooterConstants.TEST_SUITE_XML_FILES;
@@ -162,6 +163,7 @@ class BooterSerializer
             properties.setProperty( RUN_ORDER, RunOrder.asString( runOrderParameters.getRunOrder() ) );
             properties.setProperty( RUN_STATISTICS_FILE, runOrderParameters.getRunStatisticsFile() );
             properties.setProperty( RUN_ORDER_RANDOM_SEED, runOrderParameters.getRunOrderRandomSeed() );
+            properties.setProperty( SPECIFIED_RUN_ORDER, runOrderParameters.getSpecifiedRunOrder() );
         }
 
         ReporterConfiguration reporterConfiguration = providerConfiguration.getReporterConfiguration();

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerProviderConfigurationTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerProviderConfigurationTest.java
@@ -152,6 +152,17 @@ public class BooterDeserializerProviderConfigurationTest
         assertEquals( cli, reloaded.getMainCliOptions() );
     }
 
+    public void testRunOrderParameter()
+        throws IOException
+    {
+        ProviderConfiguration reloaded = getReloadedProviderConfiguration();
+
+        Assert.assertEquals( RunOrder.DEFAULT[0], reloaded.getRunOrderParameters().getRunOrder()[0] );
+        Assert.assertNull( reloaded.getRunOrderParameters().getRunStatisticsFile() );
+        Assert.assertEquals( "c1#m2,c2#m1", reloaded.getRunOrderParameters().getSpecifiedRunOrder() );
+        Assert.assertEquals( new Long( "65" ), reloaded.getRunOrderParameters().getRunOrderRandomSeed() );
+    }
+
     public void testTestRequest()
         throws IOException
     {
@@ -275,7 +286,8 @@ public class BooterDeserializerProviderConfigurationTest
             new TestRequest( getSuiteXmlFileStrings(), getTestSourceDirectory(),
                              new TestListResolver( USER_REQUESTED_TEST + "#aUserRequestedTestMethod" ),
                     RERUN_FAILING_TEST_COUNT );
-        RunOrderParameters runOrderParameters = new RunOrderParameters( RunOrder.DEFAULT, null );
+        RunOrderParameters runOrderParameters = new RunOrderParameters( RunOrder.DEFAULT, null, new Long( "65" ),
+                                                                        "c1#m2,c2#m1" );
         return new ProviderConfiguration( directoryScannerParameters, runOrderParameters, reporterConfiguration,
                 new TestArtifactInfo( "5.0", "ABC" ), testSuiteDefinition, new HashMap<String, String>(), TEST_TYPED,
                 readTestsFromInStream, cli, 0, Shutdown.DEFAULT, 0 );

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerStartupConfigurationTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerStartupConfigurationTest.java
@@ -197,7 +197,8 @@ public class BooterDeserializerStartupConfigurationTest
             new TestRequest( Arrays.asList( getSuiteXmlFileStrings() ), getTestSourceDirectory(),
                              new TestListResolver( "aUserRequestedTest#aUserRequestedTestMethod" ) );
 
-        RunOrderParameters runOrderParameters = new RunOrderParameters( RunOrder.DEFAULT, null );
+        RunOrderParameters runOrderParameters = new RunOrderParameters( RunOrder.DEFAULT, null,
+                                                                        new Long( "65" ), "c1#m2,c2#m1" );
         return new ProviderConfiguration( directoryScannerParameters, runOrderParameters, reporterConfiguration,
                 new TestArtifactInfo( "5.0", "ABC" ), testSuiteDefinition, new HashMap<String, String>(),
                 BooterDeserializerProviderConfigurationTest.TEST_TYPED, true, cli, 0, Shutdown.DEFAULT, 0 );

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/testset/RunOrderParameters.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/testset/RunOrderParameters.java
@@ -18,9 +18,11 @@ package org.apache.maven.surefire.api.testset;
  * specific language governing permissions and limitations
  * under the License.
  */
+import org.apache.maven.surefire.api.util.RunOrder;
 
 import java.io.File;
-import org.apache.maven.surefire.api.util.RunOrder;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.apache.maven.surefire.api.util.RunOrder.ALPHABETICAL;
 import static org.apache.maven.surefire.api.util.RunOrder.DEFAULT;
@@ -36,6 +38,8 @@ public final class RunOrderParameters
 
     private final Long runOrderRandomSeed;
 
+    private final String specifiedRunOrder;
+
     public RunOrderParameters( RunOrder[] runOrder, File runStatisticsFile )
     {
         this( runOrder, runStatisticsFile, null );
@@ -48,14 +52,28 @@ public final class RunOrderParameters
 
     public RunOrderParameters( String runOrder, File runStatisticsFile, Long runOrderRandomSeed )
     {
-        this( runOrder == null ? DEFAULT : RunOrder.valueOfMulti( runOrder ), runStatisticsFile, runOrderRandomSeed );
+        this( runOrder, runStatisticsFile, runOrderRandomSeed, null );
     }
 
     public RunOrderParameters( RunOrder[] runOrder, File runStatisticsFile, Long runOrderRandomSeed )
     {
+        this( runOrder, runStatisticsFile, runOrderRandomSeed, null );
+    }
+
+    public RunOrderParameters( RunOrder[] runOrder, File runStatisticsFile, Long runOrderRandomSeed,
+                               String specifiedRunOrder )
+    {
         this.runOrder = runOrder;
         this.runStatisticsFile = runStatisticsFile;
         this.runOrderRandomSeed = runOrderRandomSeed;
+        this.specifiedRunOrder = specifiedRunOrder;
+    }
+
+    public RunOrderParameters( String runOrder, File runStatisticsFile, Long runOrderRandomSeed,
+                               String specifiedRunOrder )
+    {
+        this( runOrder == null ? DEFAULT : RunOrder.valueOfMulti( runOrder ), runStatisticsFile, runOrderRandomSeed,
+              specifiedRunOrder );
     }
 
     public static RunOrderParameters alphabetical()
@@ -76,5 +94,22 @@ public final class RunOrderParameters
     public File getRunStatisticsFile()
     {
         return runStatisticsFile;
+    }
+
+    public List<ResolvedTest> resolvedSpecifiedRunOrder()
+    {
+        if ( specifiedRunOrder != null )
+        {
+            return new ArrayList<>( new TestListResolver( specifiedRunOrder ).getIncludedPatterns() );
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    public String getSpecifiedRunOrder()
+    {
+        return specifiedRunOrder;
     }
 }

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/testset/RunOrderParameters.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/testset/RunOrderParameters.java
@@ -18,6 +18,7 @@ package org.apache.maven.surefire.api.testset;
  * specific language governing permissions and limitations
  * under the License.
  */
+ 
 import org.apache.maven.surefire.api.util.RunOrder;
 
 import java.io.File;

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/util/RunOrder.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/util/RunOrder.java
@@ -44,6 +44,8 @@ public class RunOrder
 
     public static final RunOrder FAILEDFIRST = new RunOrder( "failedfirst" );
 
+    public static final RunOrder TESTORDER = new RunOrder( "testorder" );
+
     public static final RunOrder[] DEFAULT = new RunOrder[]{ FILESYSTEM };
 
     /**
@@ -108,7 +110,8 @@ public class RunOrder
 
     private static RunOrder[] values()
     {
-        return new RunOrder[]{ ALPHABETICAL, FILESYSTEM, HOURLY, RANDOM, REVERSE_ALPHABETICAL, BALANCED, FAILEDFIRST };
+        return new RunOrder[]{ ALPHABETICAL, FILESYSTEM, HOURLY, RANDOM, REVERSE_ALPHABETICAL, BALANCED, FAILEDFIRST,
+                               TESTORDER };
     }
 
     public static String asString( RunOrder[] runOrder )

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/util/RunOrderCalculator.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/util/RunOrderCalculator.java
@@ -19,10 +19,14 @@ package org.apache.maven.surefire.api.util;
  * under the License.
  */
 
+import java.util.Comparator;
+
 /**
  * @author Kristian Rosenvold
  */
 public interface RunOrderCalculator
 {
     TestsToRun orderTestClasses( TestsToRun scannedClasses );
+
+    Comparator<String> comparatorForTestMethods();
 }

--- a/surefire-api/src/test/java/org/apache/maven/surefire/api/util/RunOrderCalculatorTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/api/util/RunOrderCalculatorTest.java
@@ -19,7 +19,10 @@ package org.apache.maven.surefire.api.util;
  * under the License.
  */
 
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.surefire.api.testset.RunOrderParameters;
@@ -58,5 +61,118 @@ public class RunOrderCalculatorTest
     static class B
     {
 
+    }
+    public void testOrderTestMethods()
+    {
+        System.setProperty( "test", "TestClass#a2d,TestClass#aBc,TestClass#abc,TestClass#a1b" );
+        RunOrderParameters runOrderParameters = new RunOrderParameters( "testorder" , null,
+                                                    null, System.getProperty( "test" ) );
+        DefaultRunOrderCalculator runOrderCalculator = new DefaultRunOrderCalculator( runOrderParameters, 1 );
+        Comparator<String> testOrderRunOrderComparator = runOrderCalculator.comparatorForTestMethods();
+        String[] strArray = { "abc(TestClass)", "a1b(TestClass)", "a2d(TestClass)", "aBc(TestClass)" };
+        List<String> actual = Arrays.asList( strArray );
+        actual.sort( testOrderRunOrderComparator );
+        String[] strArray2 = { "a2d(TestClass)", "aBc(TestClass)", "abc(TestClass)", "a1b(TestClass)" };
+        List<String> expected = Arrays.asList( strArray2 );
+        assertEquals( actual, expected );
+    }
+
+    public void testOrderTestClassesAndMethods()
+    {
+        System.setProperty( "test", "TestClass1#a2d,TestClass2#aBc,TestClass2#abc,TestClass2#a1b" );
+        RunOrderParameters runOrderParameters = new RunOrderParameters( "testorder" , null,
+                                                    null, System.getProperty( "test" ) );
+        DefaultRunOrderCalculator runOrderCalculator = new DefaultRunOrderCalculator( runOrderParameters, 1 );
+        Comparator<String> testOrderRunOrderComparator = runOrderCalculator.comparatorForTestMethods();
+        String[] strArray = { "abc(TestClass2)", "a1b(TestClass2)", "a2d(TestClass1)", "aBc(TestClass2)" };
+        List<String> actual = Arrays.asList( strArray );
+        actual.sort( testOrderRunOrderComparator );
+        String[] strArray2 = { "a2d(TestClass1)", "aBc(TestClass2)", "abc(TestClass2)", "a1b(TestClass2)" };
+        List<String> expected = Arrays.asList( strArray2 );
+        assertEquals( actual, expected );
+    }
+
+    public void testOrderTestRegexClassesAndMethods()
+    {
+        System.setProperty( "test", "Amber*Test#a?c,My???Test#test*" );
+        RunOrderParameters runOrderParameters = new RunOrderParameters( "testorder" , null,
+                                                    null, System.getProperty( "test" ) );
+        DefaultRunOrderCalculator runOrderCalculator = new DefaultRunOrderCalculator( runOrderParameters, 1 );
+        Comparator<String> testOrderRunOrderComparator = runOrderCalculator.comparatorForTestMethods();
+        String[] strArray = { "abc(AmberGoodTest)",
+            "testabc(MyabcTest)",
+            "a2c(AmberBadTest)",
+            "testefg(MyefgTest)",
+            "aBc(AmberGoodTest)" };
+        List<String> actual = Arrays.asList( strArray );
+        actual.sort( testOrderRunOrderComparator );
+        assertEquals( runOrderCalculator.getClassAndMethod( actual.get( 0 ) )[0].substring( 0, 5 ), "Amber" );
+        assertEquals( runOrderCalculator.getClassAndMethod( actual.get( 1 ) )[0].substring( 0, 5 ), "Amber" );
+        assertEquals( runOrderCalculator.getClassAndMethod( actual.get( 2 ) )[0].substring( 0, 5 ), "Amber" );
+        assertEquals( runOrderCalculator.getClassAndMethod( actual.get( 3 ) )[0].substring( 0, 2 ), "My" );
+        assertEquals( runOrderCalculator.getClassAndMethod( actual.get( 4 ) )[0].substring( 0, 2 ), "My" );
+    }
+
+    public void testOrderComparatorTest()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append( "TestClass1#testa2d," );
+        sb.append( "TestClass1#testabc," );
+        sb.append( "TestClass1#testa1b," );
+        sb.append( "TestClass2#testa1b," );
+        sb.append( "TestClass2#testaBc" );
+        RunOrderParameters runOrderParameters = new RunOrderParameters( "testorder" , null,
+            null, sb.toString() );
+        DefaultRunOrderCalculator roc = new DefaultRunOrderCalculator( runOrderParameters, 1 );
+        String className = "TestClass1";
+        String className2 = "TestClass2";
+        assertTrue( ( int ) roc.testOrderComparator( className, className, "testa2d", "testa1b" ) < 0 );
+        assertTrue( ( int ) roc.testOrderComparator( className, className, "testa2d", "testabc" ) < 0 );
+        assertTrue( ( int ) roc.testOrderComparator( className, className, "testa1b", "testabc" ) > 0 );
+        assertTrue( ( int ) roc.testOrderComparator( className, className, "testa2d", "testaBc" ) > 0 );
+        assertTrue( ( int ) roc.testOrderComparator( className, className, "testa3d", "testa1b" ) < 0 );
+        assertTrue( ( int ) roc.testOrderComparator( className, className2, "testa2d", "testa1b" ) < 0 );
+        assertTrue( ( int ) roc.testOrderComparator( className2, className, "testaBc", "testa1b" ) > 0 );
+        assertTrue( ( int ) roc.testOrderComparator( className, className2, "testa3d", "testa1b" ) < 0 );
+        assertTrue( ( int ) roc.testOrderComparator( className, className2, "testa2d", "testabc" ) > 0 );
+        assertTrue( ( int ) roc.testOrderComparator( className, className, "testa2d", "testa2d" ) == 0 );
+    }
+
+    public void testRegexMethodOrderComparator()
+    {
+        StringBuilder orderParamList = new StringBuilder();
+        orderParamList.append( "TestClass1#testa?c," );
+        orderParamList.append( "TestClass1#testa?b," );
+        orderParamList.append( "TestClass2#test?1*," );
+        orderParamList.append( "!TestClass1#testa4b," );
+        orderParamList.append( "!TestClass2#test11MyTest" );
+        RunOrderParameters runOrderParameters = new RunOrderParameters( "testorder" , null,
+            null, orderParamList.toString() );
+        DefaultRunOrderCalculator roc = new DefaultRunOrderCalculator( runOrderParameters, 1 );
+        String className = "TestClass1";
+        String className2 = "TestClass2";
+        assertTrue( ( int ) roc.testOrderComparator( className, className, "testabc", "testa1b" ) < 0 );
+        assertTrue( ( int ) roc.testOrderComparator( className, className, "testaBc", "testa2b" ) < 0 );
+        assertTrue( ( int ) roc.testOrderComparator( className, className, "testa1b", "testa3c" ) > 0 );
+        assertTrue( ( int ) roc.testOrderComparator( className, className2, "testa1b", "test1123" ) < 0 );
+        assertTrue( ( int ) roc.testOrderComparator( className2, className, "testa1b", "testa1b" ) > 0 );
+        assertTrue( ( int ) roc.testOrderComparator( className2, className2, "testa1b", "test1123" ) == 0 );
+        assertTrue( ( int ) roc.testOrderComparator( className, className, "testa1c", "testa1c" ) == 0 );
+    }
+
+    public void testRegexClassOrderComparator()
+    {
+        StringBuilder orderParamList = new StringBuilder();
+        orderParamList.append( "My2*Test.java," );
+        orderParamList.append( "???My1*Test," );
+        orderParamList.append( "!abcMy1PeaceTest" );
+        RunOrderParameters runOrderParameters = new RunOrderParameters( "testorder" , null,
+                                                    null, orderParamList.toString() );
+        DefaultRunOrderCalculator roc = new DefaultRunOrderCalculator( runOrderParameters, 1 );
+        String className = "My2ConnectTest";
+        String className2 = "456My1ConnectTest";
+        assertTrue( ( int ) roc.testOrderComparator( className, className2, null, null ) < 0 );
+        assertTrue( ( int ) roc.testOrderComparator( className2, className, null, null ) > 0 );
+        assertTrue( ( int ) roc.testOrderComparator( className, className, null, null ) == 0 );
     }
 }

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterConstants.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterConstants.java
@@ -60,4 +60,5 @@ public final class BooterConstants
     public static final String PROCESS_CHECKER = "processChecker";
     public static final String FORK_NODE_CONNECTION_STRING = "forkNodeConnectionString";
     public static final String FORK_NUMBER = "forkNumber";
+    public static final String SPECIFIED_RUN_ORDER = "specifiedRunOrder";
 }

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterDeserializer.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterDeserializer.java
@@ -109,6 +109,7 @@ public class BooterDeserializer
         final String runOrder = properties.getProperty( RUN_ORDER );
         final Long runOrderRandomSeed = properties.getLongProperty( RUN_ORDER_RANDOM_SEED );
         final String runStatisticsFile = properties.getProperty( RUN_STATISTICS_FILE );
+        final String specifiedRunOrder = properties.getProperty( SPECIFIED_RUN_ORDER );
 
         final int rerunFailingTestsCount = properties.getIntProperty( RERUN_FAILING_TESTS_COUNT );
 
@@ -117,7 +118,7 @@ public class BooterDeserializer
 
         RunOrderParameters runOrderParameters
                 = new RunOrderParameters( runOrder, runStatisticsFile == null ? null : new File( runStatisticsFile ),
-                                          runOrderRandomSeed );
+                                          runOrderRandomSeed, specifiedRunOrder );
 
         TestArtifactInfo testNg = new TestArtifactInfo( testNgVersion, testArtifactClassifier );
         TestRequest testSuiteDefinition =

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/RunOrderIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/RunOrderIT.java
@@ -40,6 +40,8 @@ public class RunOrderIT
 
     private static final String[] TESTS_IN_REVERSE_ALPHABETICAL_ORDER = { "TC", "TB", "TA" };
 
+    private static final String[] TEST_IN_SPECIFIED_ORDER = { "TD#2", "TD#1", "TB" };
+
     // testing random is left as an exercise to the reader. Patches welcome
 
     @Test
@@ -183,6 +185,25 @@ public class RunOrderIT
             .withFailure()
             .executeTest()
             .verifyTextInLog( "There's no RunOrder with the name nonExistingRunOrder." );
+    }
+
+    @Test
+    public void testSpecifiedTestOrderJUnit4()
+        throws Exception
+    {
+        OutputValidator validator = executeWithTestOrder( "junit4" );
+        assertTestnamesAppearInSpecificOrder( validator, TEST_IN_SPECIFIED_ORDER );
+    }
+
+    private OutputValidator executeWithTestOrder( String profile  )
+    {
+        return unpack()
+            .activateProfile( profile )
+            .forkMode( getForkMode() )
+            .setTestToRun( "junit.runOrder.TestD#testTwo,junit.runOrder.TestD#testOne,junit.runOrder.TestB" )
+            .runOrder( "testorder" )
+            .executeTest()
+            .verifyErrorFree( 3 );
     }
 
     private OutputValidator executeWithRunOrder( String runOrder, String profile )

--- a/surefire-its/src/test/resources/runOrder/src/test/java/junit/runOrder/TestD.java
+++ b/surefire-its/src/test/resources/runOrder/src/test/java/junit/runOrder/TestD.java
@@ -1,0 +1,37 @@
+package junit.runOrder;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import junit.framework.TestCase;
+
+public class TestD
+    extends TestCase
+{
+    public void testOne()
+    {
+        System.out.println( "TD#1" );
+    }
+
+    public void testTwo()
+    {
+        System.out.println( "TD#2" );
+    }
+
+}

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/JUnitCoreProvider.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/JUnitCoreProvider.java
@@ -146,7 +146,7 @@ public class JUnitCoreProvider
 
         try
         {
-            JUnitCoreWrapper core = new JUnitCoreWrapper( notifier, jUnitCoreParameters, logger );
+            JUnitCoreWrapper core = new JUnitCoreWrapper( notifier, jUnitCoreParameters, logger, runOrderCalculator );
 
             if ( commandsReader != null )
             {
@@ -164,7 +164,8 @@ public class JUnitCoreProvider
                 listener.setRunMode( RERUN_TEST_AFTER_FAILURE );
                 Notifier rerunNotifier = pureNotifier();
                 notifier.copyListenersTo( rerunNotifier );
-                JUnitCoreWrapper rerunCore = new JUnitCoreWrapper( rerunNotifier, jUnitCoreParameters, logger );
+                JUnitCoreWrapper rerunCore = new JUnitCoreWrapper( rerunNotifier, jUnitCoreParameters, logger,
+                                                                   runOrderCalculator );
                 for ( int i = 0; i < rerunFailingTestsCount && !testFailureListener.getAllFailures().isEmpty(); i++ )
                 {
                     Set<Description> failures = generateFailingTestDescriptions( testFailureListener.getAllFailures() );

--- a/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/Surefire746Test.java
+++ b/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/Surefire746Test.java
@@ -50,7 +50,9 @@ import org.apache.maven.surefire.api.booter.ProviderParameterNames;
 import org.apache.maven.surefire.api.report.ReporterConfiguration;
 import org.apache.maven.surefire.api.report.ReporterFactory;
 import org.apache.maven.surefire.api.suite.RunResult;
+import org.apache.maven.surefire.api.testset.RunOrderParameters;
 import org.apache.maven.surefire.api.testset.TestSetFailedException;
+import org.apache.maven.surefire.api.util.DefaultRunOrderCalculator;
 import org.apache.maven.surefire.api.util.TestsToRun;
 import org.apache.maven.surefire.common.junit4.JUnit4RunListener;
 import org.apache.maven.surefire.common.junit4.Notifier;
@@ -135,7 +137,9 @@ public class Surefire746Test
             // and rethrows a failure which happened in listener
             exception.expect( TestSetFailedException.class );
             JUnit4RunListener dummy = new JUnit4RunListener( new MockReporter() );
-            new JUnitCoreWrapper( new Notifier( dummy, 0 ), jUnitCoreParameters, mock( ConsoleLogger.class ) )
+            new JUnitCoreWrapper( new Notifier( dummy, 0 ), jUnitCoreParameters,
+                                  mock( ConsoleLogger.class ),
+                                  new DefaultRunOrderCalculator( RunOrderParameters.alphabetical(), 1 ) )
                 .execute( testsToRun, customRunListeners, null );
         }
         finally


### PR DESCRIPTION
This PR is a new implement for [PR#348](https://github.com/apache/maven-surefire/pull/348).

The changes in this pull request enable Surefire to run test classes and test methods in any order specified by a newly added [&lt;runOrder&gt;](http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#runOrder) (testorder). Namely, the changes include

- A new [&lt;runOrder&gt;](http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#runOrder) called testorder that would make Surefire run test classes and test methods in the order specified by [&lt;test&gt;](http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#test). Regex and include/exclude are supported as is the case for other runOrders
- Tests for the newly added features

The newly added testorder [&lt;runOrder&gt;](http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#runOrder) is supported for JUnit 3 and JUnit 4 tests. 

Moreover, I have also implement a preliminary support for JUnit5, but I need some help to make it better. For this reason, I created another PR to show that change. Looking forward to discuss it with you developers about this issue.

**Simple (no regex) example using [Http-Request](https://github.com/kevinsawicki/http-request):**

```
mvn test -Dsurefire.runOrder=testorder \
-Dtest=com.github.kevinsawicki.http.HttpRequestTest#getUrlEncodedWithPercent,\
com.github.kevinsawicki.http.HttpRequestTest#uploadProgressSendReader,\
com.github.kevinsawicki.http.HttpRequestTest#malformedStringUrlCause,\
com.github.kevinsawicki.http.EncodeTest#encode
```

Output from Maven should say that the test class `HttpRequestTest` ran before `EncodeTest`

The file `HttpRequestTest.xml` (`http-request/lib/target/surefire-reports/TEST-com.github.kevinsawicki.http.HttpRequestTest.xml`) should say

```
<testcase name="getUrlEncodedWithPercent"...>
<testcase name="uploadProgressSendReader"...>
<testcase name="malformedStringUrlCause...>
```

**Regex example using  [Http-Request](https://github.com/kevinsawicki/http-request):**

```
mvn test -Dsurefire.runOrder=testorder \
-Dtest=com.github.kevinsawicki.http.EncodeTest*,\
com.github.kevinsawicki.http.HttpRequestTest#getUrl*
```

Output from Maven should say

```
Tests run: 2 … in 
com.github.kevinsawicki.http.EncodeTest
Tests run: 4 … in
com.github.kevinsawicki.http.HttpRequestTest
```

The file `HttpRequestTest.xml` (`http-request/lib/target/surefire-reports/TEST-com.github.kevinsawicki.http.HttpRequestTest.xml`) should say

```
<testcase name=”getUrlEncodedWithPercent”...>
<testcase name="getUrlEncodedWithSpace"...>
<testcase name="getUrlEncodedWithUnicode”...>
<testcase name="getUrlEmpty”...>
```

**Include/Exclude example using  [Http-Request](https://github.com/kevinsawicki/http-request):**

```
mvn test -Dsurefire.runOrder=testorder \
-Dtest=com.github.kevinsawicki.http.HttpRequestTest#getUrl*,\
\!com.github.kevinsawicki.http.HttpRequestTest#getUrlEmpty
```

Output from Maven should say
`Tests run: 3 … in`

`com.github.kevinsawicki.http.HttpRequestTest`

The file `HttpRequestTest.xml` (`http-request/lib/target/surefire-reports/TEST-com.github.kevinsawicki.http.HttpRequestTest.xml`) should say

```
<testcase name=”getUrlEncodedWithPercent”...>
<testcase name="getUrlEncodedWithSpace"...>
<testcase name="getUrlEncodedWithUnicode”...>
```